### PR TITLE
Sauvegarder et restaurer les données utilisateur et bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Scripts
 - Migration Postgres: `npm run migrate:pg`
 
 Déploiement Render
-- Build Command: `npm ci`
-- Start Command: `node src/bot.js`
-- Ajouter `DATABASE_URL` si Postgres (recommandé). Lancer ensuite `npm run migrate:pg` une fois.
+- Build Command: `npm run render-build`
+- Start Command: `npm run render-start`
+- Ajouter `DATABASE_URL` (Postgres Render) est recommandé. Au premier déploiement, la build exécutera la migration depuis `data/config.json` si présent.
  - Variables d'env:
    - `DISCORD_TOKEN`: token du bot
    - `CLIENT_ID`: application client id
@@ -27,10 +27,20 @@ Déploiement Render
    - `DATA_DIR` (optionnel, si pas de Postgres): chemin vers un volume monté (ex: `/var/data`)
 
 Persistance
-- Si `DATABASE_URL` est défini (et `pg` installée), la config est persistée dans Postgres (table `app_config`). Au premier run, si vide, bootstrap depuis `data/config.json` s'il existe.
-- Sinon, la config est lue/écrite sur disque dans `DATA_DIR` (par défaut `./data`). Sur Render, créez un Volume et pointez `DATA_DIR` vers son point de montage.
+- Si `DATABASE_URL` est défini (et `pg` installée), la config est persistée dans Postgres (table `app_config`).
+- Au démarrage Render, un script restaure la config fichier depuis Postgres vers `data/config.json` pour permettre l’édition/export via endpoints.
+- Sans Postgres, la config est lue/écrite sur disque dans `DATA_DIR` (par défaut `./data`). Sur Render, créez un Volume et pointez `DATA_DIR` vers son point de montage.
 
 Restauration
 - Avec Postgres: rien à faire, les données sont conservées entre déploiements.
 - Sans Postgres: assurez-vous que `DATA_DIR` persiste (Volume) et que `data/config.json` est présent. Le bot crée la structure si absente.
+
+Sauvegarde/Restaurations manuelles
+- Exporter la config (slash command ou HTTP):
+  - `GET /config.json` (protégé par `CONFIG_TOKEN` si défini)
+  - Dans Discord: `/config export`
+- Importer/restaurer:
+  - `POST /config.json` avec corps JSON compatible
+  - Dans Discord: `/config import` avec pièce jointe JSON
+- Snapshots: chaque écriture crée un backup dans `data/backups/` (conserve 5 derniers). En mode Postgres, une table `app_config_history` garde un historique minimal.
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,22 @@
+services:
+  - type: web
+    name: bag-discord-bot
+    env: node
+    autoDeploy: true
+    plan: free
+    buildCommand: npm run render-build
+    startCommand: npm run render-start
+    envVars:
+      - key: DISCORD_TOKEN
+        value: ""
+      - key: CLIENT_ID
+        value: ""
+      - key: GUILD_ID
+        value: ""
+      - key: DATABASE_URL
+        fromDatabase:
+          name: bag-bot-db
+          property: connectionString
+databases:
+  - name: bag-bot-db
+    plan: free


### PR DESCRIPTION
Add Render deployment blueprint and update README to enable persistent storage of user data and bot configuration.

Previously, bot data and configuration would reset on every Render redeployment due to a lack of persistent storage setup. This PR introduces a `render.yaml` blueprint for easy deployment with a managed PostgreSQL database, and updates the `README.md` to guide users on configuring persistent storage (either via Postgres or a Render Volume for file-based persistence), ensuring data is retained.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cc923a6-9bf4-4f91-ac8f-69a51b9e4510">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cc923a6-9bf4-4f91-ac8f-69a51b9e4510">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

