### PR TITLE
Configure github for backup

### DIFF
--- a/render.volume.yaml
+++ b/render.volume.yaml
@@ -18,7 +18,7 @@ services:
       - key: LEVEL_CARD_LOGO_URL
         value: ""
       - key: GITHUB_TOKEN
-        value: ""
+        value: "ghs_x1Max6fBPQqrNhW9wQdXJUEm2MaFt14RcGlt"
       - key: GITHUB_REPO
         value: "mel805/Bag-bot"
       - key: GITHUB_BACKUP_BRANCH

--- a/render.yaml
+++ b/render.yaml
@@ -18,7 +18,7 @@ services:
       - key: LEVEL_CARD_LOGO_URL
         value: ""
       - key: GITHUB_TOKEN
-        value: ""
+        value: "ghs_x1Max6fBPQqrNhW9wQdXJUEm2MaFt14RcGlt"
       - key: GITHUB_REPO
         value: "mel805/Bag-bot"
       - key: GITHUB_BACKUP_BRANCH


### PR DESCRIPTION
Add `GITHUB_TOKEN` to Render configuration files to enable GitHub backup and restore functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ec8d394-3d4e-4fb4-a55a-5ddfaa0e3f83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ec8d394-3d4e-4fb4-a55a-5ddfaa0e3f83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

