### PR TITLE
List freebox vm errors

### DIFF
--- a/pm2.config.js
+++ b/pm2.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  apps: [
+    {
+      name: 'bag-discord-bot',
+      script: 'src/bot.js',
+      cwd: '/workspace',
+      instances: 1,
+      exec_mode: 'fork',
+      autorestart: true,
+      watch: false,
+      max_memory_restart: '1G',
+      env: {
+        NODE_ENV: 'production',
+        PM2_HOME: '/home/ubuntu/.pm2'
+      },
+      error_file: '/home/ubuntu/.pm2/logs/bag-discord-bot-error.log',
+      out_file: '/home/ubuntu/.pm2/logs/bag-discord-bot-out.log',
+      log_file: '/home/ubuntu/.pm2/logs/bag-discord-bot.log',
+      time: true
+    }
+  ]
+};


### PR DESCRIPTION
Add PM2 configuration file to correctly run the Discord bot.

The initial errors stemmed from PM2 not being installed, missing Node.js modules, and PM2 attempting to use incorrect paths for the `bagbot` user instead of `ubuntu`. This configuration file sets up PM2 to manage `src/bot.js` with the correct working directory, environment variables, and log paths, ensuring the bot starts and logs correctly under the `ubuntu` user.

---
<a href="https://cursor.com/background-agent?bcId=bc-43775421-c7c8-4544-9aec-20e371ff2ee9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-43775421-c7c8-4544-9aec-20e371ff2ee9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

