### PR TITLE
Fix syntax errors

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -4066,7 +4066,7 @@ client.login(process.env.DISCORD_TOKEN).then(() => {
   console.error('Login failed:', err?.message || err);
   process.exit(1);
 });
-client.once(Events.ClientReady, (readyClient) => {
+client.once(Events.ClientReady, async (readyClient) => {
   console.log(`Logged in as ${readyClient.user.tag}`);
   // Boot persistance dès le départ et journaliser le mode choisi
   ensureStorageExists().then(()=>console.log('[bot] Storage initialized')).catch((e)=>console.warn('[bot] Storage init error:', e?.message||e));


### PR DESCRIPTION
Add `async` keyword to `ClientReady` event callback to resolve a `SyntaxError` when using `await`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e788d2d-8c46-440b-843d-ca1ee3dba500">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3e788d2d-8c46-440b-843d-ca1ee3dba500">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

