### PR TITLE
Remove ping for silent actions

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1178,9 +1178,11 @@ async function handleEconomyAction(interaction, actionKey) {
         + (thirdCharmDelta ? `, Charme ${thirdCharmDelta>=0?'+':''}${thirdCharmDelta}` : '')
         + (thirdPervDelta ? `, Perversion ${thirdPervDelta>=0?'+':''}${thirdPervDelta}` : '');
       global.__eco_tromper_third = { name: 'Sanction du tiers', value: thirdFieldVal, inline: false };
-      // Store pings for content (partner + third)
-      const tromperPings = [partner, third].filter(Boolean).map(u => `<@${u.id}>`).join(' ');
-      global.__eco_tromper_pings = tromperPings;
+      // Store pings for content (partner + third) - only if there's a specific target
+      if (partner || third) {
+        const tromperPings = [partner, third].filter(Boolean).map(u => `<@${u.id}>`).join(' ');
+        global.__eco_tromper_pings = tromperPings;
+      }
     }
     console.log('[Tromper] Tromper logic completed successfully');
   }
@@ -1293,8 +1295,10 @@ async function handleEconomyAction(interaction, actionKey) {
       const label = `Participants (${everyone.length})`;
       const val = `${list}`;
       global.__eco_orgie_participants = { name: label, value: val, inline: false };
-      // Store pings for content
-      global.__eco_orgie_pings = list;
+      // Store pings for content - only if there's a specific initial partner/target
+      if (partner) {
+        global.__eco_orgie_pings = list;
+      }
     }
     console.log('[Orgie] Orgie logic completed successfully');
   }

--- a/src/storage/jsonStore.js
+++ b/src/storage/jsonStore.js
@@ -714,9 +714,6 @@ function ensureEconomyShape(g) {
   }
   if (!e.actions.config || typeof e.actions.config !== 'object') e.actions.config = {};
   
-  // Configuration pour les pings dans les actions spéciales
-  if (typeof e.actions.config.disablePings !== 'boolean') e.actions.config.disablePings = false;
-  
   // Ensure karmaModifiers structure exists and is valid
   if (!e.karmaModifiers || typeof e.karmaModifiers !== 'object') {
     e.karmaModifiers = { shop: [], actions: [], grants: [] };

--- a/src/storage/jsonStore.js
+++ b/src/storage/jsonStore.js
@@ -714,6 +714,9 @@ function ensureEconomyShape(g) {
   }
   if (!e.actions.config || typeof e.actions.config !== 'object') e.actions.config = {};
   
+  // Configuration pour les pings dans les actions spéciales
+  if (typeof e.actions.config.disablePings !== 'boolean') e.actions.config.disablePings = false;
+  
   // Ensure karmaModifiers structure exists and is valid
   if (!e.karmaModifiers || typeof e.karmaModifiers !== 'object') {
     e.karmaModifiers = { shop: [], actions: [], grants: [] };


### PR DESCRIPTION
Remove pings for `tromper` and `orgie` economy actions when no specific target is provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-4deaa3bf-ec2a-4388-b255-e4c53a1291fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4deaa3bf-ec2a-4388-b255-e4c53a1291fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

